### PR TITLE
Fix bad memory access in Mersenne twister.

### DIFF
--- a/xatlas.cpp
+++ b/xatlas.cpp
@@ -1723,6 +1723,10 @@ public:
 		seed(s);
 	}
 
+	// The "next" pointer makes the default copy constructor unsafe, so delete it.
+	MTRand(const MTRand&) = delete;
+	MTRand& operator=(const MTRand&) = delete;
+
 	/// Provide a new seed.
 	void seed( uint32_t s )
 	{
@@ -7032,7 +7036,6 @@ struct AtlasPacker
 				XA_PRINT("   Estimating texelsPerUnit as %g\n", m_texelsPerUnit);
 			}
 		}
-		m_rand = MTRand();
 		Array<float> chartOrderArray;
 		chartOrderArray.resize(chartCount);
 		Array<Vector2> chartExtents;


### PR DESCRIPTION
Address sanitizer noticed that the next pointer in MTRand points to
freed memory when used from AtlasPacker. This is because a copy is made
using the default copy constructor. As far as I can tell, there is no
reason to make this copy.

This commit not only removes the needless copy in AtlasPacker, it also
deletes the default copy constructor to prevent this error from being
made elsewhere.