### PR TITLE
Fix spatial hash that determines colocality.

### DIFF
--- a/xatlas.cpp
+++ b/xatlas.cpp
@@ -662,7 +662,7 @@ static Vector3 normalizeSafe(const Vector3 &v, const Vector3 &fallback, float ep
 
 static bool equal(const Vector3 &v0, const Vector3 &v1, float epsilon = XA_EPSILON)
 {
-	return fabs(v0.x - v1.x) <= epsilon && fabs(v0.y - v1.y) <= epsilon && fabs(v0.z - v1.z) <= epsilon;
+	return equal(v0.x, v1.x, epsilon) && equal(v0.y, v1.y, epsilon) && equal(v0.z, v1.z, epsilon);
 }
 
 static Vector3 min(const Vector3 &a, const Vector3 &b)
@@ -691,14 +691,6 @@ struct Vector3Hash
 		data[1] = (int32_t)(v.y * 100.0f);
 		data[2] = (int32_t)(v.z * 100.0f);
 		return sdbmHash(data, sizeof(data));
-	}
-};
-
-struct Vector3Equal
-{
-	bool operator()(const Vector3 &v0, const Vector3 &v1) const
-	{
-		return equal(v0, v1);
 	}
 };
 
@@ -2805,7 +2797,7 @@ public:
 	void createColocals()
 	{
 		const uint32_t vertexCount = m_positions.size();
-		HashMap<Vector3, uint32_t, Vector3Hash, Vector3Equal> positionMap(vertexCount);
+		HashMap<Vector3, uint32_t, Vector3Hash> positionMap(vertexCount);
 		for (uint32_t i = 0; i < m_positions.size(); i++)
 			positionMap.add(m_positions[i], i);
 		Array<uint32_t> colocals;


### PR DESCRIPTION
This fixes a common cause for asserting at the bottom of createColocals
and subsequently crashing (e.g. the GearboxAssy glTF conformance model).

HashMap assumes that if any two keys are "equal", then they map
to the same hash value. The colocality hash was violating this because
it used a epsilon-based equivalency test.

Note that the original Thekla code does not have this issue, it simply
uses the default equivalency test.

On a side note, the equivalency test for Vector3 was not using the same
method that Vector2 was using (Christer Ericson's 2008 post).