### PR TITLE
Do not create worker with no ThreadLocal storage

### DIFF
--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -3139,7 +3139,7 @@ public:
 			m_groups[i].ref = 0;
 			m_groups[i].userData = nullptr;
 		}
-		m_workers.resize(std::thread::hardware_concurrency() <= 1 ? 1 : std::thread::hardware_concurrency() - 1);
+		m_workers.resize(std::thread::hardware_concurrency() <= 1 ? 0 : std::thread::hardware_concurrency() - 1);
 		for (uint32_t i = 0; i < m_workers.size(); i++) {
 			new (&m_workers[i]) Worker();
 			m_workers[i].wakeup = false;


### PR DESCRIPTION
When compiled with multithreading enabled and run with a CPU count of 1, the task scheduler would create 1 worker thread. However, `ThreadLocal<T>` will not allocate any storage for this worker thread during its initialization, as the array length is determined from CPU count and not worker count. This generally results in the worker thread segfaulting, e.g. when trying to dereference an uninitialized pointer.

Proposed fix: Do not create any worker threads when run with 1 CPU.

