### PR TITLE
fix computeFaceNormal: use corner whose angle is closest to right angle for cross product

### DIFF
--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -814,6 +814,12 @@ static float length(const Vector3 &v)
 	return sqrtf(lengthSquared(v));
 }
 
+static float angle(const Vector3 &a, const Vector3 &b)
+{
+	const Vector3 c = cross(a, b);
+	return abs(atan2(length(c), dot(a, b)));
+}
+
 static bool isNormalized(const Vector3 &v, float epsilon = kNormalEpsilon)
 {
 	return equal(length(v), 1.0f, epsilon);
@@ -2707,9 +2713,27 @@ public:
 		const Vector3 &p0 = m_positions[m_indices[face * 3 + 0]];
 		const Vector3 &p1 = m_positions[m_indices[face * 3 + 1]];
 		const Vector3 &p2 = m_positions[m_indices[face * 3 + 2]];
-		const Vector3 e0 = p2 - p0;
-		const Vector3 e1 = p1 - p0;
-		const Vector3 normalAreaScaled = cross(e0, e1);
+		const Vector3 e00 = p2 - p0;
+		const Vector3 e01 = p1 - p0;
+		const Vector3 e10 = p0 - p1;
+		const Vector3 e11 = p2 - p1;
+		const Vector3 e20 = p1 - p2;
+		const Vector3 e21 = p0 - p2;
+
+		// use the corner whose angle is the closest to a right angle,
+		// as that will give the most stable results for the cross product calculation
+		const float diff0 = abs(M_PI * 0.5f - angle(e00, e01));
+		const float diff1 = abs(M_PI * 0.5f - angle(e10, e11));
+		const float diff2 = abs(M_PI * 0.5f - angle(e20, e21));
+		Vector3 normalAreaScaled;
+		if (diff0 <= diff1 && diff0 <= diff2) {
+			normalAreaScaled = cross(e00, e01);
+		} else if (diff1 <= diff0 && diff1 <= diff2) {
+			normalAreaScaled = cross(e10, e11);
+		} else {
+			normalAreaScaled = cross(e20, e21);
+		}
+
 		return normalizeSafe(normalAreaScaled, Vector3(0, 0, 1));
 	}
 

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -47,6 +47,7 @@ Copyright (c) 2012 Brandon Pelfrey
 #include <assert.h>
 #include <float.h> // FLT_MAX
 #include <limits.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
@@ -2722,9 +2723,9 @@ public:
 
 		// use the corner whose angle is the closest to a right angle,
 		// as that will give the most stable results for the cross product calculation
-		const float diff0 = abs(M_PI * 0.5f - angle(e00, e01));
-		const float diff1 = abs(M_PI * 0.5f - angle(e10, e11));
-		const float diff2 = abs(M_PI * 0.5f - angle(e20, e21));
+		const float diff0 = abs(M_PI_2 - angle(e00, e01));
+		const float diff1 = abs(M_PI_2 - angle(e10, e11));
+		const float diff2 = abs(M_PI_2 - angle(e20, e21));
 		Vector3 normalAreaScaled;
 		if (diff0 <= diff1 && diff0 <= diff2) {
 			normalAreaScaled = cross(e00, e01);

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -818,7 +818,7 @@ static float length(const Vector3 &v)
 static float angle(const Vector3 &a, const Vector3 &b)
 {
 	const Vector3 c = cross(a, b);
-	return abs(atan2(length(c), dot(a, b)));
+	return abs(atan2f(length(c), dot(a, b)));
 }
 
 static bool isNormalized(const Vector3 &v, float epsilon = kNormalEpsilon)

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -47,7 +47,6 @@ Copyright (c) 2012 Brandon Pelfrey
 #include <assert.h>
 #include <float.h> // FLT_MAX
 #include <limits.h>
-#define _USE_MATH_DEFINES
 #include <math.h>
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
@@ -436,6 +435,7 @@ static void *Realloc(void *ptr, size_t size, int /*tag*/, const char * /*file*/,
 
 static constexpr float kPi = 3.14159265358979323846f;
 static constexpr float kPi2 = 6.28318530717958647692f;
+static constexpr float kPi_Half = 1.57079632679489661923f;
 static constexpr float kEpsilon = 0.0001f;
 static constexpr float kAreaEpsilon = FLT_EPSILON;
 static constexpr float kNormalEpsilon = 0.001f;
@@ -2723,9 +2723,9 @@ public:
 
 		// use the corner whose angle is the closest to a right angle,
 		// as that will give the most stable results for the cross product calculation
-		const float diff0 = abs(M_PI_2 - angle(e00, e01));
-		const float diff1 = abs(M_PI_2 - angle(e10, e11));
-		const float diff2 = abs(M_PI_2 - angle(e20, e21));
+		const float diff0 = abs(kPi_Half - angle(e00, e01));
+		const float diff1 = abs(kPi_Half - angle(e10, e11));
+		const float diff2 = abs(kPi_Half - angle(e20, e21));
 		Vector3 normalAreaScaled;
 		if (diff0 <= diff1 && diff0 <= diff2) {
 			normalAreaScaled = cross(e00, e01);


### PR DESCRIPTION
This change provides a fix for issue https://github.com/jpcy/xatlas/issues/130.

* adding a method `angle` that calculates the angle between 2 Vector3 objects
* modifying the `Mesh.computeFaceNormal` method: verify the angles of all face vertices, and use the vertex whose angle is the closest to a right angle (90°). This makes the cross product numerically more stable.