### PR TITLE
Fixes of Quads and NGons.

### DIFF
--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -7385,7 +7385,7 @@ public:
 			// Computing charts checks for flipped triangles and boundary intersection. Don't need to do that again here if chart is planar.
 			if (m_type != ChartType::Planar && m_generatorType != segment::ChartGeneratorType::OriginalUv) {
 				XA_PROFILE_START(parameterizeChartsEvaluateQuality)
-				if (options.computeBoundaryIntersection)  // intersect edges. It can create artifacts (little peeces).
+				if (options.computeBoundaryIntersection)  // intersect edges. It can create artifacts (little pieces).
 					m_quality.computeBoundaryIntersection(m_unifiedMesh, boundaryGrid);
 				m_quality.computeFlippedFaces(m_unifiedMesh, nullptr);
 				m_quality.computeMetrics(m_unifiedMesh);

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -6901,8 +6901,6 @@ private:
 			if (m_vertexInPatch.get(freeVertex)) {
 // #if 0
 				// If the free vertex is already in the patch, the face is enclosed by the patch. Add the face to the patch - don't need to assign texcoords.
-				if (m_faceInAnyPatch.get(oface))
-					continue;
 				freeVertex = UINT32_MAX;
 				addFaceToPatch(oface);
 // #endif

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -6804,7 +6804,6 @@ struct PiecewiseParam
 		if (hasQuadsOrNGons) {
 			// Add other triangles of already added Quads/NGons
 			for (uint32_t f1 = 0; f1 < m_patch.size(); f1++) {
-				// uint32_t polygonID = m_mesh->trianglesToPolygonIDs[f]; // ID of a Quad/NGon
 				const uint32_t i_face = m_patch[f1];
 				const uint32_t faceQuadOrNGonID = m_mesh->trianglesToPolygonIDs[i_face];
 				const uint32_t nextFace = i_face + 1;
@@ -6833,7 +6832,6 @@ struct PiecewiseParam
 					}
 				}
 			}
-			
 		}
 		return true;
 	}

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -9184,17 +9184,18 @@ AddMeshError AddMesh(Atlas *atlas, const MeshDecl &meshDecl, uint32_t meshCountH
 		}
 		// Check for zero area faces.
 		if (!ignore) {
+			float area;  // Area of all triangles of the polygon.
 			for (uint32_t i = 0; i < triIndices.size(); i += 3) {
 				const internal::Vector3 &a = mesh->position(triIndices[i + 0]);
 				const internal::Vector3 &b = mesh->position(triIndices[i + 1]);
 				const internal::Vector3 &c = mesh->position(triIndices[i + 2]);
-				const float area = internal::length(internal::cross(b - a, c - a)) * 0.5f;
-				if (area <= internal::kAreaEpsilon) {
-					ignore = true;
-					if (++warningCount <= kMaxWarnings)
-						XA_PRINT("   Zero area face: %d, area is %f\n", face, area);
-					break;
-				}
+				area += internal::length(internal::cross(b - a, c - a)) * 0.5f;
+				if (area > internal::kAreaEpsilon) break;  // Optimisation for high polygonal NGons
+			}
+			if (area <= internal::kAreaEpsilon) {
+				ignore = true;
+				if (++warningCount <= kMaxWarnings)
+					XA_PRINT("   Zero area face: %d, area is %f\n", face, area);
 			}
 		}
 		// User face ignore.

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -5243,14 +5243,14 @@ struct PlanarCharts
 						continue; // Already in a chart.
 					// if Triangle is a part of a Quad/NGon.
 					if (hasQuadsOrNGons) {
-						if (m_data.mesh->trianglesToPolygonIDs[face] == m_data.mesh->trianglesToPolygonIDs[oface]) {
+						if (m_data.mesh->trianglesToPolygonIDs[face] == m_data.mesh->trianglesToPolygonIDs[oface]
+							&& face != oface) {
 							const uint32_t next = m_nextRegionFace[face];
 							m_nextRegionFace[face] = oface;
 							m_nextRegionFace[oface] = next;
 							m_faceToRegionId[oface] = regionCount;
 							faceStack.push_back(oface);
 							parsedFaces[oface] = true; // set parsed
-							parsedFaces[face] = true;  // set parsed
 							continue;
 						}
 					}
@@ -6899,11 +6899,11 @@ private:
 			}
 			XA_DEBUG_ASSERT(freeVertex != UINT32_MAX);
 			if (m_vertexInPatch.get(freeVertex)) {
-// #if 0
+#if 0
 				// If the free vertex is already in the patch, the face is enclosed by the patch. Add the face to the patch - don't need to assign texcoords.
 				freeVertex = UINT32_MAX;
 				addFaceToPatch(oface);
-// #endif
+#endif
 				continue;
 			}
 			// Check this here rather than above so faces enclosed by the patch are always added.

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -9184,7 +9184,7 @@ AddMeshError AddMesh(Atlas *atlas, const MeshDecl &meshDecl, uint32_t meshCountH
 		}
 		// Check for zero area faces.
 		if (!ignore) {
-			float area;  // Area of all triangles of the polygon.
+			float area = 0.0f;  // Area of all triangles of the polygon.
 			for (uint32_t i = 0; i < triIndices.size(); i += 3) {
 				const internal::Vector3 &a = mesh->position(triIndices[i + 0]);
 				const internal::Vector3 &b = mesh->position(triIndices[i + 1]);

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -8880,7 +8880,7 @@ private:
 // Used to map triangulated polygons back to polygons.
 struct MeshPolygonMapping
 {
-	internal::Array<uint8_t> faceVertexCount; // Copied from MeshDecl::faceVertexCount.
+	internal::Array<uint32_t> faceVertexCount; // Copied from MeshDecl::faceVertexCount.
 	internal::Array<uint32_t> triangleToPolygonMap; // Triangle index (mesh face index) to polygon index.
 	internal::Array<uint32_t> triangleToPolygonIndicesMap; // Triangle indices to polygon indices.
 };

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -3486,13 +3486,13 @@ struct Triangulator
 			m_polygonPoints.reserve(edgeCount);
 			m_polygonAngles.clear();
 			m_polygonAngles.reserve(edgeCount);
-			// A temporary array for indicesIDs
-			Array<uint32_t> indicesIDsTmp;
+			m_indicesIDs.clear();
+			m_indicesIDs.reserve(edgeCount);
 			for (uint32_t i = 0; i < inputIndices.size(); i++) {
 				m_polygonVertices.push_back(inputIndices[i]);
 				const Vector3 &pos = vertices[inputIndices[i]];
 				m_polygonPoints.push_back(Vector2(dot(basis.tangent, pos), dot(basis.bitangent, pos)));
-				indicesIDsTmp.push_back(i);
+				m_indicesIDs.push_back(i);
 			}
 			m_polygonAngles.resize(edgeCount);
 			while (m_polygonVertices.size() > 2) {
@@ -3540,11 +3540,11 @@ struct Triangulator
 				outputIndices.push_back(m_polygonVertices[i0]);
 				outputIndices.push_back(m_polygonVertices[i1]);
 				outputIndices.push_back(m_polygonVertices[i2]);
-				outindicesIDs.push_back(indicesIDsTmp[i0]);  // Add Index of Array of Vertex Indices
-				outindicesIDs.push_back(indicesIDsTmp[i1]);
-				outindicesIDs.push_back(indicesIDsTmp[i2]);
+				outindicesIDs.push_back(m_indicesIDs[i0]);  // Add Index of Array of Vertex Indices
+				outindicesIDs.push_back(m_indicesIDs[i1]);
+				outindicesIDs.push_back(m_indicesIDs[i2]);
 				m_polygonVertices.removeAt(i1);
-				indicesIDsTmp.removeAt(i1);
+				m_indicesIDs.removeAt(i1);
 				m_polygonPoints.removeAt(i1);
 				m_polygonAngles.removeAt(i1);
 			}
@@ -3560,6 +3560,7 @@ private:
 	Array<int> m_polygonVertices;
 	Array<float> m_polygonAngles;
 	Array<Vector2> m_polygonPoints;
+	Array<uint32_t> m_indicesIDs;  // indexes of polygon's Indices array
 };
 
 class UniformGrid2

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -6815,6 +6815,11 @@ struct PiecewiseParam
 							m_faceInPatch.set(f);
 							m_faceInAnyPatch.set(f);
 							if(m_faceInvalid.get(f)) m_faceInvalid.unset(f);
+							// Add all 3 vertices.
+							for (uint32_t i = 0; i < 3; i++) {
+								const uint32_t vertex = m_mesh->vertexAt(f * 3 + i);
+								if(!m_vertexInPatch.get(f)) m_vertexInPatch.set(vertex);
+							}
 						}
 					}
 					else {break;}
@@ -6828,6 +6833,11 @@ struct PiecewiseParam
 								m_faceInPatch.set(f);
 								m_faceInAnyPatch.set(f);
 								if(m_faceInvalid.get(f)) m_faceInvalid.unset(f);
+								// // Add all 3 vertices.
+								for (uint32_t i = 0; i < 3; i++) {
+									const uint32_t vertex = m_mesh->vertexAt(f * 3 + i);
+									if(!m_vertexInPatch.get(f)) m_vertexInPatch.set(vertex);
+								}
 							}
 						}
 						else {break;}

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -3475,7 +3475,7 @@ struct Triangulator
 			outindicesIDs.push_back(1);
 			outindicesIDs.push_back(2);
 		}
-		else if (inputIndices.size() == 3) {
+		else if (inputIndices.size() == 4) {
 			// Simple case for quads.
 			outputIndices.push_back(inputIndices[0]);
 			outputIndices.push_back(inputIndices[1]);

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -3475,21 +3475,21 @@ struct Triangulator
 			outindicesIDs.push_back(1);
 			outindicesIDs.push_back(2);
 		}
-		else if (inputIndices.size() == 4) {
-			// Simple case for quads.
-			outputIndices.push_back(inputIndices[0]);
-			outputIndices.push_back(inputIndices[1]);
-			outputIndices.push_back(inputIndices[2]);
-			outindicesIDs.push_back(0);
-			outindicesIDs.push_back(1);
-			outindicesIDs.push_back(2);
-			outputIndices.push_back(inputIndices[0]);
-			outputIndices.push_back(inputIndices[2]);
-			outputIndices.push_back(inputIndices[3]);
-			outindicesIDs.push_back(0);
-			outindicesIDs.push_back(2);
-			outindicesIDs.push_back(3);
-		}
+		// else if (inputIndices.size() == 4) {
+		// 	// Simple case for quads.
+		// 	outputIndices.push_back(inputIndices[0]);
+		// 	outputIndices.push_back(inputIndices[1]);
+		// 	outputIndices.push_back(inputIndices[2]);
+		// 	outindicesIDs.push_back(0);
+		// 	outindicesIDs.push_back(1);
+		// 	outindicesIDs.push_back(2);
+		// 	outputIndices.push_back(inputIndices[0]);
+		// 	outputIndices.push_back(inputIndices[2]);
+		// 	outputIndices.push_back(inputIndices[3]);
+		// 	outindicesIDs.push_back(0);
+		// 	outindicesIDs.push_back(2);
+		// 	outindicesIDs.push_back(3);
+		// }
 		else {
 			// Build 2D polygon projecting vertices onto normal plane.
 			// Faces are not necesarily planar, this is for example the case, when the face comes from filling a hole. In such cases

--- a/source/xatlas/xatlas.cpp
+++ b/source/xatlas/xatlas.cpp
@@ -9118,7 +9118,6 @@ AddMeshError AddMesh(Atlas *atlas, const MeshDecl &meshDecl, uint32_t meshCountH
 				polygon[i] = polygonStartID + i;
 			}
 		}
-		
 		// Ignore faces with degenerate or zero length edges.
 		bool ignore = false;
 		for (uint32_t i = 0; i < faceVertexCount; i++) {

--- a/source/xatlas/xatlas.h
+++ b/source/xatlas/xatlas.h
@@ -190,7 +190,7 @@ struct ChartOptions
 	bool useInputMeshUvs = false; // Use MeshDecl::vertexUvData for charts.
 	bool fixWinding = false; // Enforce consistent texture coordinate winding.
 
-	bool computeBoundaryIntersection = false; // Used in parameterize() to intersect edges. It can create artifacts (little peeces).
+	bool computeBoundaryIntersection = false; // Used in parameterize() to intersect edges. It can create artifacts (little pieces).
 };
 
 // Call after all AddMesh calls. Can be called multiple times to recompute charts with different options.

--- a/source/xatlas/xatlas.h
+++ b/source/xatlas/xatlas.h
@@ -189,8 +189,6 @@ struct ChartOptions
 
 	bool useInputMeshUvs = false; // Use MeshDecl::vertexUvData for charts.
 	bool fixWinding = false; // Enforce consistent texture coordinate winding.
-
-	bool computeBoundaryIntersection = false; // Used in parameterize() to intersect edges. It can create artifacts (little pieces).
 };
 
 // Call after all AddMesh calls. Can be called multiple times to recompute charts with different options.

--- a/source/xatlas/xatlas.h
+++ b/source/xatlas/xatlas.h
@@ -123,7 +123,7 @@ struct MeshDecl
 
 	// Optional. Must be faceCount in length.
 	// Polygon / n-gon support. Faces are assumed to be triangles if this is null.
-	const uint8_t *faceVertexCount = nullptr;
+	const uint32_t *faceVertexCount = nullptr;
 
 	uint32_t vertexCount = 0;
 	uint32_t vertexPositionStride = 0;

--- a/source/xatlas/xatlas.h
+++ b/source/xatlas/xatlas.h
@@ -189,6 +189,8 @@ struct ChartOptions
 
 	bool useInputMeshUvs = false; // Use MeshDecl::vertexUvData for charts.
 	bool fixWinding = false; // Enforce consistent texture coordinate winding.
+
+	bool computeBoundaryIntersection = false; // Used in parameterize() to intersect edges. It can create artifacts (little peeces).
 };
 
 // Call after all AddMesh calls. Can be called multiple times to recompute charts with different options.

--- a/source/xatlas/xatlas_c.h
+++ b/source/xatlas/xatlas_c.h
@@ -191,6 +191,7 @@ typedef struct
 	uint32_t maxIterations;
 	bool useInputMeshUvs;
 	bool fixWinding;
+	bool computeBoundaryIntersection;
 }
 xatlasChartOptions;
 

--- a/source/xatlas/xatlas_c.h
+++ b/source/xatlas/xatlas_c.h
@@ -139,7 +139,7 @@ typedef struct
 	const void *indexData;
 	const bool *faceIgnoreData;
 	const uint32_t *faceMaterialData;
-	const uint8_t *faceVertexCount;
+	const uint32_t *faceVertexCount;
 	uint32_t vertexCount;
 	uint32_t vertexPositionStride;
 	uint32_t vertexNormalStride;

--- a/source/xatlas/xatlas_c.h
+++ b/source/xatlas/xatlas_c.h
@@ -191,7 +191,6 @@ typedef struct
 	uint32_t maxIterations;
 	bool useInputMeshUvs;
 	bool fixWinding;
-	bool computeBoundaryIntersection;
 }
 xatlasChartOptions;
 


### PR DESCRIPTION
Hi, I made fixes for Quads and NGons. Now all works as a charm without crashes! 

My video explanation of changes:
https://youtu.be/d9MWNfvQLtc

Some key points:
- AddMesh() function was fixed
- "polygon" variable was converted to an Array to have an unlimited amount of points for NGons.
-  indicesIDs array is added to apply ids
- Fixed indices.
- triangulatePolygon() was updated. It also outputs indicesIDs.
- Changes were tested in Blender with many objects which had Quads and NGons. All warks like a charm!

Without these changes XAtlas will be crashing.

Pics:
![image](https://github.com/user-attachments/assets/e834e564-0d30-478c-9406-5a0919a26b21)

![image](https://github.com/user-attachments/assets/f5f2b492-f1a4-4d18-99c3-73d737ec9bb4)

![image](https://github.com/user-attachments/assets/4bb9ab66-19f6-460f-a19c-0975adf74ad8)

![image](https://github.com/user-attachments/assets/57848dec-16fd-41e7-bebc-e9536097eef4)

![image](https://github.com/user-attachments/assets/85ceb6a2-b612-426a-a59a-63ddf1a430da)


Generated UVs in Blender with XAtlas:
![image](https://github.com/user-attachments/assets/11e83fb5-afcd-4a3b-bfdc-7a35742922ae)
![image](https://github.com/user-attachments/assets/f438887a-f055-4de2-9606-e7b3530e2805)

![image](https://github.com/user-attachments/assets/d29a917f-4cae-4551-9c3e-c4347cf349fd)
![image](https://github.com/user-attachments/assets/ae17897d-a985-4d8a-af2e-d92b6e678fb5)
